### PR TITLE
Add a way to keep a shell around after tmux exits.

### DIFF
--- a/shells/tmux.sh
+++ b/shells/tmux.sh
@@ -16,7 +16,11 @@ if [ -z "$TMUX" ]; then
       tmux new-session -t login \; new-window -a -t $last_session # Create a *new* session bound to "login" and create a new window
     fi
 
-    # When Tmux exits, we exit
-    exit
+    # When Tmux exits, we exit. Unless we want to keep the shell
+    if [[ -f "/tmp/keep-shell-$USER" ]]; then
+      rm "/tmp/keep-shell-$USER"
+    else
+      exit
+    fi
   fi
 fi


### PR DESCRIPTION
Sometimes to prevent nesting you need a normal shell if you want to SSH
into another system and then use tmux there.

I've added the following line to my tmux.conf:

``` tmux
bind e run "touch /tmp/keep-shell-$USER" \; kill-window
```
